### PR TITLE
allow retries for unknownEngineID error

### DIFF
--- a/lib/netsnmp/client.rb
+++ b/lib/netsnmp/client.rb
@@ -155,7 +155,7 @@ module NETSNMP
       retries = @retries
       begin
         yield
-      rescue Timeout::Error, IdNotInTimeWindowError => e
+      rescue Timeout::Error, IdNotInTimeWindowError, UnknownEngineIdError => e
         raise e if retries.zero?
 
         retries -= 1

--- a/lib/netsnmp/errors.rb
+++ b/lib/netsnmp/errors.rb
@@ -7,6 +7,8 @@ module NETSNMP
 
   class AuthenticationFailed < Error; end
 
+  class UnknownEngineIdError < Error; end
+
   class IdNotInTimeWindowError < Error; end
 
   class OidNotFound < StandardError; end

--- a/lib/netsnmp/v3_session.rb
+++ b/lib/netsnmp/v3_session.rb
@@ -93,7 +93,7 @@ module NETSNMP
         when "1.3.6.1.6.3.15.1.1.3.0" # usmStatsUnknownUserNames
           raise Error, "Unknown user name"
         when "1.3.6.1.6.3.15.1.1.4.0" # usmStatsUnknownEngineIDs
-          raise Error, "Unknown engine ID" unless @security_parameters.must_revalidate?
+          raise UnknownEngineIdError, "Unknown engine ID" unless @security_parameters.must_revalidate?
         when "1.3.6.1.6.3.15.1.1.5.0" # usmStatsWrongDigests
           raise Error, "Authentication failure (incorrect password, community or key)"
         when "1.3.6.1.6.3.15.1.1.6.0" # usmStatsDecryptionErrors

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -8,6 +8,9 @@ module NETSNMP
   class AuthenticationFailed < Error
   end
 
+  class UnknownEngineIdError < Error
+  end
+
   class IdNotInTimeWindowError < Error
   end
 end


### PR DESCRIPTION
snmp agents may lose engine state in between, and the usmUnknownEngineID error should therefore trigger a retry, just like "id not in time window" error does

Closes #3 